### PR TITLE
Adding default on HostKeyCallback

### DIFF
--- a/forward.go
+++ b/forward.go
@@ -188,6 +188,7 @@ func (s *Server) SessionForward(session *Session, newChannel ssh.NewChannel, cha
 	ag := agent.NewClient(agentChan)
 
 	clientConfig := &ssh.ClientConfig{
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		User: session.Conn.User(),
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeysCallback(ag.Signers),


### PR DESCRIPTION
Since this issue golang/go#19767 the default behaviour of HostKeyCallback changed, so the old behaviour can be achieved with this change.